### PR TITLE
Fix: Pin SonarCloud action to specific commit SHA for security

### DIFF
--- a/.github/workflows/gestion_asientos.yml
+++ b/.github/workflows/gestion_asientos.yml
@@ -55,7 +55,7 @@ jobs:
   
         # Analizar cobertura de código con SonarCloud
       - name: SonarCloud Scan with coverage
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@d08d592c0b694607865c089cba90bbf87c9a6d89
         with:
           args: >
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Este PR actualiza el archivo de workflow para utilizar un commit SHA específico en lugar de la referencia mutable `master` para la acción `SonarSource/sonarcloud-github-action`. Esto mejora la seguridad al asegurar que se usa una versión fija de la acción.

SHA específico: d08d592c0b694607865c089cba90bbf87c9a6d89